### PR TITLE
apk: add wolfi repo support

### DIFF
--- a/apk/README.md
+++ b/apk/README.md
@@ -9,5 +9,4 @@ Uses Chainguard's go-apk library to resolve a list of alpine packages into a DAG
 - Rough draft but works
 - Need to
   - turn into a real, customizable interface (just hard codes a lot of stuff)
-  - support more repos such as wolfi
   - get "lazy remote rebasing" working fully

--- a/apk/main.go
+++ b/apk/main.go
@@ -52,6 +52,7 @@ func (m *Apk) Build(
 	debugPkgs Optional[bool],
 	wolfi Optional[bool],
 ) (*Container, error) {
+	// TODO: what should this repo interface look like?
 	m.Wolfi = wolfi.GetOr(false)
 	repo := goapk.NewRepositoryFromComponents(
 		alpineRepository,
@@ -87,6 +88,7 @@ func (m *Apk) Build(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get alpine packages: %w", err)
 	}
+	// TODO: i dont think we need to error here
 	//if len(conflicts) > 0 {
 	//	return nil, fmt.Errorf("failed to get alpine packages with conflicts: %v", conflicts)
 	//}
@@ -147,6 +149,7 @@ func (m *Apk) Build(
 		if triggerFile != nil {
 			ctr = ctr.
 				WithMountedFile("/tmp/script", triggerFile).
+				// TODO: triggers failing for git package on wolfi
 //				WithExec([]string{"/tmp/script"}).
 				WithoutMount("/tmp/script")
 		}


### PR DESCRIPTION
Question:

How should the interface look to choose alpine vs wolfi? For now I added `wolfi Optional[bool]` but that's not a great solution

Question/Comment:

For the `conflicts` returned by `pkgResolver.GetPackagesWithDependencies`, I believe those are just the list of conflicts declared by the packages themselves, not a conflict with the resolved package dependencies. Since we're installing all packages to a scratch container, I _think_ we can just ignore `conflicts` since we don't have a base OS to check for the potentially conflicted packages.